### PR TITLE
Merge packages.csv and packages.raw.cs files

### DIFF
--- a/code/transform.py
+++ b/code/transform.py
@@ -1,3 +1,4 @@
+from pprint import pprint
 from frictionless import Resource, transform, steps
 
 
@@ -5,8 +6,9 @@ from frictionless import Resource, transform, steps
 
 
 transform(
-    Resource("data/packages.raw.csv"),
+    Resource(path="data/packages.csv"),
     steps=[
+        steps.table_merge(resource=Resource(path="data/packages.raw.csv")),
         steps.table_normalize(),
         steps.row_sort(field_names=["stars"], reverse=True),
         steps.table_write(path="data/packages.csv"),


### PR DESCRIPTION
# Overview

As said in #1, every new Github Search will return a different set of packages. Merging packages.csv and packages.raw.cs prevent dataset loss.

As suggested Frictionless Transform merging function was used to perform that.

---

Please preserve this line to notify @roll (lead of this repository)
